### PR TITLE
Lower type bounds of Path.get(PluralAttribute) and Path.get(MapAttribute)

### DIFF
--- a/javax.persistence-api/src/main/java/javax/persistence/criteria/Path.java
+++ b/javax.persistence-api/src/main/java/javax/persistence/criteria/Path.java
@@ -57,7 +57,7 @@ public interface Path<X> extends Expression<X> {
      *  @param collection collection-valued attribute
      *  @return expression corresponding to the referenced attribute
      */
-    <E, C extends java.util.Collection<E>> Expression<C> get(PluralAttribute<X, C, E> collection);
+    <E, C extends java.util.Collection<E>> Expression<C> get(PluralAttribute<? super X, C, E> collection);
 
     /**
      *  Create a path corresponding to the referenced 
@@ -65,7 +65,7 @@ public interface Path<X> extends Expression<X> {
      *  @param map map-valued attribute
      *  @return expression corresponding to the referenced attribute
      */
-    <K, V, M extends java.util.Map<K, V>> Expression<M> get(MapAttribute<X, K, V> map);
+    <K, V, M extends java.util.Map<K, V>> Expression<M> get(MapAttribute<? super X, K, V> map);
 
     /**
      *  Create an expression corresponding to the type of the path.


### PR DESCRIPTION
Added lower type bounds to the entity argument X of the return value of `Path.get(PluralAttribute)` and `Path.get(MapAttribute)`. The absense of these lower bounds prevent usage of the JPA criteria API for a collection field f which is declared in an entity A which then is extended by another entity B and used in the type bounds of `TypedQuery`.

closes #108